### PR TITLE
Finalise terms of team contract

### DIFF
--- a/TeamContract.md
+++ b/TeamContract.md
@@ -92,4 +92,4 @@ By signing below, we acknowledge that we have read, discussed, and agreed to the
 3. Phoebe Kuang
 4. Caroline Lyu
 5. Bill Huang
-6. (type name here)
+6. Abish Kulkarni


### PR DESCRIPTION
- Moved terms from `TeamContract-draft.md` to the actual `TeamContract.md`
- Added some clarifications and definitions
- Added new stipulation under the conflict resolution section, stolen directly from the sample contract provided on Quercus.
  > If the issue persists, the team will involve a member of the course teaching team as mediator.

feel free to request changes