### PR TITLE
`CourseDataRepository` interface to share course data loading between Search & Save/Load use cases

### DIFF
--- a/src/main/java/data_access/course_data/CourseDataRepository.java
+++ b/src/main/java/data_access/course_data/CourseDataRepository.java
@@ -12,4 +12,5 @@ public interface CourseDataRepository {
      * @return The corresponding course offering, if it exists. Otherwise, null.
      */
     CourseOffering getCourseOffering(String courseOfferingIdentifier);
+    Set<String> getAllCourseOfferingIdentifiers();
 }

--- a/src/main/java/data_access/course_data/JsonCourseDataRepository.java
+++ b/src/main/java/data_access/course_data/JsonCourseDataRepository.java
@@ -69,4 +69,9 @@ public class JsonCourseDataRepository implements CourseDataRepository {
     public CourseOffering getCourseOffering(String courseOfferingIdentifier) {
         return availableCourseOfferings.get(courseOfferingIdentifier);
     }
+
+    @Override
+    public Set<String> getAllCourseOfferingIdentifiers() {
+        return availableCourseOfferings.keySet();
+    }
 }


### PR DESCRIPTION
I checked at office hours today (2025-11-21) that doing something like this is ok, even if it doesn't exactly fit the "typical scenario" Clean Architecture diagram.

Having this class will allow the _Save_ and _Load_ (#22, #23, #24) use cases' data access object to delegate to one of these `CourseDataRepository` instances, while the _Search for Courses_ (#28) uses case's data access object can _also_ delegate to the same object, which means we only have the json files loaded once into memory, and don't have to create duplicate entity instances for the same course offerings or the same sections.

- @CarolineLyu, since you're working on the searching for courses use case, does this work for you? Obviously, when you need more methods, you can modify the interface as needed.
- also @Abish-27, this is where the linked tutorial-lecture sections data would presumably be loaded in. if you need this data for your use case as soon as possible, feel free to push commits to this branch to implement it